### PR TITLE
Update pcap-dnsproxy.procd.init

### DIFF
--- a/package/external/chengr28/pcap-dnsproxy/files/pcap-dnsproxy.procd.init
+++ b/package/external/chengr28/pcap-dnsproxy/files/pcap-dnsproxy.procd.init
@@ -7,11 +7,9 @@ START=95
 USE_PROCD=1
 #PROCD_DEBUG=1
 
-EXTRA_COMMANDS="status flush libver"
-EXTRA_HELP=\
-"	flush	Flush DNS cache stored in Pcap_DNSProxy and DNSMasq
-	libver	Print library version Pcap_DNSProxy linked to
-	status	Show the running status of Pcap_DNSProxy"
+extra_command "flush" "Flush DNS cache stored in Pcap_DNSProxy and DNSMasq"
+extra_command "libver" "Print library version Pcap_DNSProxy linked to"
+extra_command "status" "Show the running status of Pcap_DNSProxy"
 
 PROG=/usr/sbin/Pcap_DNSProxy
 CONFDIR=/etc/pcap-dnsproxy
@@ -54,7 +52,7 @@ start_service() {
 		procd_set_param user root # run service as user root
 		procd_set_param stdout 1 # forward stdout of the command to logd
 		procd_set_param stderr 1 # same for stderr
-		procd_set_param limits nofile="unlimited"
+		procd_set_param limits nofile="2097152 2097152"
 		[ -e /proc/sys/kernel/core_pattern ] && {
 			procd_append_param limits core="unlimited"
 		}


### PR DESCRIPTION
Fix it can not start with the new proc, And make the ulimit -n wrok better.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
